### PR TITLE
hardware/README.md: add Q3 Q4

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -48,6 +48,7 @@ The following parts are a little generic, but you try to get the suggested ones 
 
 ```
 1,RGT16BM65DTL,Q2
+2,AO3422,Q3 Q4
 1,TL3301AF160QJ,SW3
 1,MURA160T3G,D2
 4,SM4005PL-TP,D1 D3 D4 D5


### PR DESCRIPTION
First of all, thanks for open sourcing the design! Very excited to try it out.

Q3 and Q4 where missing from the table. This PR adds `AO3422` as from the xls BOM.

The suggest sub part (PMV37ENEAR) is now also out of stock on digikey/farnell. Any suggestions for a different sub?

I also made a list with Farnell part numbers (https://docs.google.com/spreadsheets/d/1lR9KH1mVs3pNZHqpcGG9F5pi7PmbyUwxurxPG0W1xi4/edit?usp=sharing). Feel free to use that list for whatever you want.