### PR TITLE
Improved PIO aided triggering (with a delay)

### DIFF
--- a/firmware/c/CMakeLists.txt
+++ b/firmware/c/CMakeLists.txt
@@ -8,7 +8,7 @@ pico_sdk_init()
 
 add_executable(picoemp)
 
-pico_generate_pio_header(picoemp ${CMAKE_CURRENT_LIST_DIR}/trigger.pio)
+pico_generate_pio_header(picoemp ${CMAKE_CURRENT_LIST_DIR}/trigger_basic.pio)
 
 
 target_sources(picoemp PRIVATE

--- a/firmware/c/picoemp.c
+++ b/firmware/c/picoemp.c
@@ -7,6 +7,7 @@
 
 #include <stdio.h>
 
+const uint32_t PIN_IN_TRIGGER = 0; // also GP0 on the board
 const uint32_t PIN_LED_HV = 6;
 const uint32_t PIN_LED_STATUS = 7;
 const uint32_t PIN_BTN_PULSE = 11;

--- a/firmware/c/picoemp.h
+++ b/firmware/c/picoemp.h
@@ -4,6 +4,7 @@
 #include "hardware/pwm.h"
 #include "hardware/clocks.h"
 
+extern const uint32_t PIN_IN_TRIGGER;
 extern const uint32_t PIN_LED_HV;
 extern const uint32_t PIN_LED_STATUS;
 extern const uint32_t PIN_BTN_PULSE;

--- a/firmware/c/serial.h
+++ b/firmware/c/serial.h
@@ -13,6 +13,9 @@
 #define cmd_config_pulse_time 9
 #define cmd_config_pulse_power 10
 #define cmd_toggle_gp1 11
+#define cmd_config_pulse_delay_cycles 12
+#define cmd_config_pulse_time_cycles 13
+
 #define return_ok 0
 #define return_failed 1
 

--- a/firmware/c/trigger_basic.pio
+++ b/firmware/c/trigger_basic.pio
@@ -1,0 +1,74 @@
+.program trigger_basic
+.side_set 2
+
+; These bits have to be consecutive in the GPIO index too
+; bit 0 : gpio_pulse_go
+; bit 1 : gpio_trigger_out_debug
+
+.wrap_target
+                                    ; todo: enable autopull
+                                    ; actually mov from osr with autopull is undefined, 
+                                    ; so dont enable autopull
+    pull block          side 0b00
+    mov x osr           side 0b00   ; read delay into scratch x
+    pull block          side 0b00
+    mov y osr           side 0b00   ; read length into scratch y
+    irq clear 0         side 0b00   ; clear IRQ before starting
+    wait 1 PIN 0        side 0b10   ; wait for trigger input to go high (polarity=1), 
+                                    ; on the first input gpio (defined below),
+                                    ; and sideset gpio_trigger_out_debug high
+    ; nop                 side 0b10   ;      -> nop instead of wait, gpio_trigger_out_debug high
+delay_loop:
+    jmp x-- delay_loop  side 0b10   ; count down the delay
+pulse_loop:
+    jmp y-- pulse_loop  side 0b01   ; count down the pulse length
+    irq set 0           side 0b00   ; pulse stop, signal that program is finished with IRQ
+.wrap
+
+% c-sdk {
+static inline void trigger_basic_init(PIO pio, uint sm, uint offset, 
+    uint trigger_in, uint trigger_pulse_go) {
+
+    // TODO: trigger_in
+
+    pio_sm_config c = trigger_basic_program_get_default_config(offset);
+
+    // trigger_out_debug follows trigger_pulse_go sequentually
+    // void pio_sm_set_consecutive_pindirs (PIO pio,
+    //     uint sm,
+    //     uint pin_base,
+    //     uint pin_count,
+    //     bool is_out)
+    pio_sm_set_consecutive_pindirs(pio, sm, trigger_pulse_go, 2, true);
+
+    pio_sm_set_consecutive_pindirs(pio, sm, trigger_in, 1, false);
+
+    // init the GPIOs
+    pio_gpio_init(pio, trigger_in);
+    pio_gpio_init(pio, trigger_pulse_go);
+    pio_gpio_init(pio, trigger_pulse_go+1);
+
+    // configure the sideset pin count
+    // static void sm_config_set_sideset (pio_sm_config *c,
+    //     uint bit_count,
+    //     bool optional,
+    //     bool pindirs)
+    sm_config_set_sideset(&c, 2, false, false);
+    
+    // configure the sideset pins
+    // static void sm_config_set_sideset_pins (pio_sm_config *c,
+    //     uint sideset_base)
+    // trigger_out_debug follows trigger_pulse_go sequentually
+    sm_config_set_sideset_pins(&c, trigger_pulse_go);
+
+    // configure input pins
+    // static void sm_config_set_in_pins (pio_sm_config *c,
+    //    uint in_base)
+    sm_config_set_in_pins(&c, trigger_in);
+
+    // Load our configuration, and jump to the start of the program
+    pio_sm_init(pio, sm, offset, &c);
+    // Set the state machine running
+    pio_sm_set_enabled(pio, sm, true);
+}
+%}


### PR DESCRIPTION
Summary of changes:
- Add a configurable delay to the PIO trigger program (i.e. fast_trigger). This (and the pulse duration) are counted in 125MHz cycles.
- Use `side` for controlling outputs instead of `set` instruction.

One downside with `fast_trigger` is that there is currently not any kind of timeout implemented, so if the input trigger never comes, the serial interface hangs there forever. 

Another maybe downside in general is that serial interface is becoming a bit convoluted with all the options and inputs. For example, now there are two configurable `pulse_time`s, one that goes into a `sleep_us` and one that goes into the PIO program.