### PR TITLE
Test LED functionality

### DIFF
--- a/firmware/c/main.c
+++ b/firmware/c/main.c
@@ -79,10 +79,23 @@ int main() {
 
     picoemp_init();
 
+    //Test LED
+    // All ON for 1s and then all OFF
+    gpio_put(PIN_LED_HV, true);
+    gpio_put(PIN_LED_STATUS, true);
+    gpio_put(PIN_LED_CHARGE_ON, true);
+    sleep_ms(1000);
+    gpio_put(PIN_LED_HV, false);
+    gpio_put(PIN_LED_STATUS, false);
+    gpio_put(PIN_LED_CHARGE_ON, false);
+    
     // Init for reset pin (move somewhere else)
     gpio_init(1);
     gpio_set_dir(1, GPIO_OUT);
     gpio_put(1, 1);
+
+    //Now initialization is really complete, we can power on STATUS
+    gpio_put(PIN_LED_STATUS, true);
 
     // Run serial-console on second core
     multicore_launch_core1(serial_console);

--- a/firmware/c/picoemp.c
+++ b/firmware/c/picoemp.c
@@ -103,9 +103,7 @@ void picoemp_init() {
     gpio_set_dir(PIN_LED_HV, GPIO_OUT);
     gpio_set_dir(PIN_LED_STATUS, GPIO_OUT);
     gpio_set_dir(PIN_LED_CHARGE_ON, GPIO_OUT);
-    // Enable status LED
-    gpio_put(PIN_LED_STATUS, true);
-
+    
     // Initialize button GPIOs
     gpio_init(PIN_BTN_ARM);
     gpio_init(PIN_BTN_PULSE);
@@ -118,7 +116,6 @@ void picoemp_init() {
     gpio_set_pulls(PIN_BTN_PULSE, true, false);
     // Invert PULSE input so we can read ARM & PULSE both as active-high
     gpio_set_inover(PIN_BTN_PULSE, GPIO_OVERRIDE_INVERT);
-
 
     // Charge-detection coming from HV side
     gpio_init(PIN_IN_CHARGED);


### PR DESCRIPTION
Added in the main a brief power ON and OFF for all LEDs, so at startup we can chek if LEDs are working correctly.
LEDs in this board are very small and it is very easy to invert polarity.
Also checking HV led functionality is very important.
Removed from picoemp.c the status led and moved to main when the initialization is really complete.