### PR TITLE
arm button debounce, adjustable charging frequency, command logging and name improvements

### DIFF
--- a/firmware/c/main.c
+++ b/firmware/c/main.c
@@ -68,7 +68,7 @@ void fast_trigger() {
     if (offset == 0xFFFFFFFF) { // Only load the program once
         offset = pio_add_program(pio, &trigger_basic_program);
     }
-    
+
     // Find a free state machine on our chosen PIO (erroring if there are
     // none). Configure it to run our program, and start it, using the
     // helper function we included in our .pio file.
@@ -199,6 +199,6 @@ int main() {
             disarm();
         }
     }
-    
+
     return 0;
 }

--- a/firmware/c/main.c
+++ b/firmware/c/main.c
@@ -9,10 +9,19 @@
 
 #include "trigger_basic.pio.h"
 
-static bool armed = false;
+typedef enum armed_state {
+    DISARMED = 0,
+    ARMED = 1,
+    REARMED = 2,
+} armed_state_t;
+
+#define BTN_DEBOUNCE_TIME_MS 50
+
+static armed_state_t armed = DISARMED;
 static bool timeout_active = true;
 static bool hvp_internal = true;
 static absolute_time_t timeout_time;
+static absolute_time_t arm_debounce_time = 0;
 static uint offset = 0xFFFFFFFF;
 
 // defaults taken from original code
@@ -27,18 +36,22 @@ static union float_union {float f; uint32_t ui32;} pulse_power;
 
 void arm() {
     gpio_put(PIN_LED_CHARGE_ON, true);
-    armed = true;
+    if(armed == ARMED) {
+        armed = REARMED;
+    } else {
+        armed = ARMED;
+    }
 }
 
 void disarm() {
     gpio_put(PIN_LED_CHARGE_ON, false);
-    armed = false;
+    armed = DISARMED;
     picoemp_disable_pwm();
 }
 
 uint32_t get_status() {
     uint32_t result = 0;
-    if(armed) {
+    if(armed != DISARMED) {
         result |= 0b1;
     }
     if(gpio_get(PIN_IN_CHARGED)) {
@@ -180,23 +193,30 @@ int main() {
             // YOLO debouncing by picoemp_pulse forced 250ms recovery
         }
 
+        // Arming
         if(gpio_get(PIN_BTN_ARM)) {
             update_timeout();
-            if(!armed) {
-                arm();
-            } else {
-                disarm();
+            if(!arm_debounce_time) {
+                arm_debounce_time = make_timeout_time_ms(BTN_DEBOUNCE_TIME_MS);
+                (armed != DISARMED ? disarm : arm)();
+            } else if(arm_debounce_time > get_absolute_time()) {
+                arm_debounce_time = make_timeout_time_ms(BTN_DEBOUNCE_TIME_MS);
             }
-            // YOLO debouncing
-            while(gpio_get(PIN_BTN_ARM));
-            sleep_ms(100);
         }
 
-        if(!gpio_get(PIN_IN_CHARGED) && armed) {
+        if (arm_debounce_time && arm_debounce_time < get_absolute_time()) {
+            arm_debounce_time = 0;
+        }
+
+        if(armed == ARMED && !gpio_get(PIN_IN_CHARGED)) {
             picoemp_enable_pwm(pulse_power.f);
+        } else if(armed == REARMED) {
+            picoemp_disable_pwm();
+            picoemp_enable_pwm(pulse_power.f);
+            armed = ARMED;
         }
 
-        if(timeout_active && (get_absolute_time() > timeout_time) && armed) {
+        if(armed != DISARMED && timeout_active && (get_absolute_time() > timeout_time)) {
             disarm();
         }
     }

--- a/firmware/c/main.c
+++ b/firmware/c/main.c
@@ -20,6 +20,8 @@ static uint offset = 0xFFFFFFFF;
 #define PULSE_TIME_CYCLES_DEFAULT 625 // 5us in 8ns cycles
 #define PULSE_TIME_US_DEFAULT 5 // 5us
 #define PULSE_POWER_DEFAULT 0.0122
+#define CHARGE_FREQ_DEFAULT 2500 // 2.5 kHz
+static uint32_t charge_freq;
 static uint32_t pulse_time;
 static uint32_t pulse_delay_cycles;
 static uint32_t pulse_time_cycles;
@@ -93,6 +95,7 @@ int main() {
     // Run serial-console on second core
     multicore_launch_core1(serial_console);
 
+    charge_freq = CHARGE_FREQ_DEFAULT;
     pulse_time = PULSE_TIME_US_DEFAULT;
     pulse_power.f = PULSE_POWER_DEFAULT;
     pulse_delay_cycles = PULSE_DELAY_CYCLES_DEFAULT;
@@ -158,6 +161,10 @@ int main() {
                     hvp_internal = false;
                     multicore_fifo_push_blocking(return_ok);
                     break;
+                case cmd_config_charge_freq:
+                    charge_freq = multicore_fifo_pop_blocking();
+                    multicore_fifo_push_blocking(return_ok);
+                    break;
                 case cmd_config_pulse_time:
                     pulse_time = multicore_fifo_pop_blocking();
                     multicore_fifo_push_blocking(return_ok);
@@ -192,7 +199,7 @@ int main() {
         }
 
         if(!gpio_get(PIN_IN_CHARGED) && armed) {
-            picoemp_enable_pwm(pulse_power.f);
+            picoemp_enable_pwm(pulse_power.f, charge_freq);
         }
 
         if(timeout_active && (get_absolute_time() > timeout_time) && armed) {

--- a/firmware/c/main.c
+++ b/firmware/c/main.c
@@ -177,6 +177,7 @@ int main() {
         if(gpio_get(PIN_BTN_PULSE)) {
             update_timeout();
             picoemp_pulse(pulse_time);
+            // YOLO debouncing by picoemp_pulse forced 250ms recovery
         }
 
         if(gpio_get(PIN_BTN_ARM)) {

--- a/firmware/c/main.c
+++ b/firmware/c/main.c
@@ -19,11 +19,11 @@ static uint offset = 0xFFFFFFFF;
 #define PULSE_DELAY_CYCLES_DEFAULT 0
 #define PULSE_TIME_CYCLES_DEFAULT 625 // 5us in 8ns cycles
 #define PULSE_TIME_US_DEFAULT 5 // 5us
-#define PULSE_POWER_DEFAULT 0.0122
+#define CHARGE_DUTY_DEFAULT 0.0122
 static uint32_t pulse_time;
 static uint32_t pulse_delay_cycles;
 static uint32_t pulse_time_cycles;
-static union float_union {float f; uint32_t ui32;} pulse_power;
+static union float_union {float f; uint32_t ui32;} charge_duty;
 
 void arm() {
     gpio_put(PIN_LED_CHARGE_ON, true);
@@ -94,7 +94,7 @@ int main() {
     multicore_launch_core1(serial_console);
 
     pulse_time = PULSE_TIME_US_DEFAULT;
-    pulse_power.f = PULSE_POWER_DEFAULT;
+    charge_duty.f = CHARGE_DUTY_DEFAULT;
     pulse_delay_cycles = PULSE_DELAY_CYCLES_DEFAULT;
     pulse_time_cycles = PULSE_TIME_CYCLES_DEFAULT;
 
@@ -162,8 +162,8 @@ int main() {
                     pulse_time = multicore_fifo_pop_blocking();
                     multicore_fifo_push_blocking(return_ok);
                     break;
-                case cmd_config_pulse_power:
-                    pulse_power.ui32 = multicore_fifo_pop_blocking();
+                case cmd_config_charge_duty:
+                    charge_duty.ui32 = multicore_fifo_pop_blocking();
                     multicore_fifo_push_blocking(return_ok);
                     break;
                 case cmd_toggle_gp1:
@@ -192,7 +192,7 @@ int main() {
         }
 
         if(!gpio_get(PIN_IN_CHARGED) && armed) {
-            picoemp_enable_pwm(pulse_power.f);
+            picoemp_enable_pwm(charge_duty.f);
         }
 
         if(timeout_active && (get_absolute_time() > timeout_time) && armed) {

--- a/firmware/c/picoemp.c
+++ b/firmware/c/picoemp.c
@@ -38,7 +38,7 @@ uint32_t pwm_set_freq_duty(uint slice_num,
     return wrap;
 }
 
-void picoemp_enable_pwm(float duty_frac) {
+void picoemp_enable_pwm(float duty_frac, uint32_t freq) {
     if(pwm_enabled) {
         return;
     }
@@ -57,7 +57,7 @@ void picoemp_enable_pwm(float duty_frac) {
     // Init PWM, but don't start it yet
     pwm_init(slice, &config, false);
     // pwm_set_chan_level(slice, PWM_CHAN_A, 800); // pretty sure this line is pointless
-    pwm_set_freq_duty(slice, PWM_CHAN_A, 2500, duty_frac);
+    pwm_set_freq_duty(slice, PWM_CHAN_A, freq, duty_frac);
     pwm_set_enabled(slice, true);
     pwm_enabled = true;
 }

--- a/firmware/c/picoemp.c
+++ b/firmware/c/picoemp.c
@@ -73,6 +73,7 @@ void picoemp_pulse(uint32_t pulse_time) {
     gpio_put(PIN_OUT_HVPULSE, true);
     sleep_us(pulse_time);
     gpio_put(PIN_OUT_HVPULSE, false);
+    // force 250ms recovery time
     sleep_ms(250);
 }
 

--- a/firmware/c/picoemp.c
+++ b/firmware/c/picoemp.c
@@ -25,16 +25,16 @@ uint32_t pwm_set_freq_duty(uint slice_num,
 {
     uint32_t clock = clock_get_hz(clk_sys);
     uint32_t divider16 = clock / f / 4096 + (clock % (f * 4096) != 0);
-    
+
     if (divider16 / 16 == 0)
         divider16 = 16;
-    
+
     uint32_t wrap = clock * 16 / divider16 / f - 1;
-    
+
     pwm_set_clkdiv_int_frac(slice_num, divider16/16, divider16 & 0xF);
     pwm_set_wrap(slice_num, wrap);
     pwm_set_chan_level(slice_num, chan, (int)((float)wrap * d));
-    
+
     return wrap;
 }
 
@@ -46,7 +46,7 @@ void picoemp_enable_pwm(float duty_frac) {
     // Get PWM slice
     uint32_t slice = pwm_gpio_to_slice_num(PIN_OUT_HVPWM);
     gpio_set_function(PIN_OUT_HVPWM, GPIO_FUNC_PWM);
-    
+
     // Set up clock divider
     float target_frequency = 25;
     float divider = clock_get_hz(clk_sys) / target_frequency;

--- a/firmware/c/picoemp.h
+++ b/firmware/c/picoemp.h
@@ -14,7 +14,7 @@ extern const uint32_t PIN_OUT_HVPWM;
 extern const uint32_t PIN_LED_CHARGE_ON;
 extern const uint32_t PIN_BTN_ARM;
 
-void picoemp_enable_pwm(float duty_frac);
+void picoemp_enable_pwm(float duty_frac, uint32_t freq);
 void picoemp_disable_pwm();
 void picoemp_pulse(uint32_t pulse_time);
 void picoemp_configure_pulse_output();

--- a/firmware/c/serial.c
+++ b/firmware/c/serial.c
@@ -172,7 +172,7 @@ bool handle_command(char *command) {
             printf("Using default\n");
         else
             pulse_delay_cycles = strtoul(serial_buffer, unused, 10);
-        
+
         printf(" pulse_time_cycles (current: %d, default: %d)?\n> ", pulse_time_cycles, PULSE_TIME_CYCLES_DEFAULT);
         read_line();
         printf("\n");
@@ -259,7 +259,7 @@ bool handle_command(char *command) {
 
     if(strcmp(command, "t") == 0 || strcmp(command, "toggle_gp1") == 0) {
         multicore_fifo_push_blocking(cmd_toggle_gp1);
-        
+
         uint32_t result = multicore_fifo_pop_blocking();
         if(result != return_ok) {
             printf("target_reset failed.");
@@ -285,7 +285,7 @@ void serial_console() {
     pulse_power.f = PULSE_POWER_DEFAULT;
     pulse_delay_cycles = PULSE_DELAY_CYCLES_DEFAULT;
     pulse_time_cycles = PULSE_TIME_CYCLES_DEFAULT;
-    
+
     while(1) {
         read_line();
         printf("\n");
@@ -308,7 +308,7 @@ void serial_console() {
             printf("- [r]eset\n");
         }
         printf("\n");
-        
+
         if (last_command[0] != 0) {
             printf("[%s] > ", last_command);
         } else {

--- a/firmware/c/serial.c
+++ b/firmware/c/serial.c
@@ -15,10 +15,12 @@ static char last_command[256];
 #define PULSE_TIME_CYCLES_DEFAULT 625 // 5us in 8ns cycles
 #define PULSE_TIME_US_DEFAULT 5 // 5us
 #define PULSE_POWER_DEFAULT 0.0122
+#define CHARGE_FREQ_DEFAULT 2500 // 2.5 kHz
 static uint32_t pulse_time;
 static uint32_t pulse_delay_cycles;
 static uint32_t pulse_time_cycles;
 static union float_union {float f; uint32_t ui32;} pulse_power;
+static uint32_t charge_freq;
 
 void read_line() {
     memset(serial_buffer, 0, sizeof(serial_buffer));
@@ -238,6 +240,14 @@ bool handle_command(char *command) {
         else
             pulse_power.f = strtof(serial_buffer, unused);
 
+        printf(" charge_freq (current: %d, default: %d)?\n> ", charge_freq, CHARGE_FREQ_DEFAULT);
+        read_line();
+        printf("\n");
+        if (serial_buffer[0] == 0)
+            printf("Using default\n");
+        else
+            charge_freq = strtoul(serial_buffer, unused, 10);
+
         multicore_fifo_push_blocking(cmd_config_pulse_time);
         multicore_fifo_push_blocking(pulse_time);
         uint32_t result = multicore_fifo_pop_blocking();
@@ -252,7 +262,14 @@ bool handle_command(char *command) {
             printf("Config pulse_power failed.");
         }
 
-        printf("pulse_time=%d, pulse_power=%f\n", pulse_time, pulse_power.f);
+        multicore_fifo_push_blocking(cmd_config_charge_freq);
+        multicore_fifo_push_blocking(charge_freq);
+        result = multicore_fifo_pop_blocking();
+        if(result != return_ok) {
+            printf("Config charge_freq failed.");
+        }
+
+        printf("pulse_time=%d, pulse_power=%f, charge_freq=%d\n", pulse_time, pulse_power.f, charge_freq);
 
         return true;
     }
@@ -282,9 +299,10 @@ void serial_console() {
     memset(last_command, 0, sizeof(last_command));
 
     pulse_time = PULSE_TIME_US_DEFAULT;
-    pulse_power.f = PULSE_POWER_DEFAULT;
     pulse_delay_cycles = PULSE_DELAY_CYCLES_DEFAULT;
     pulse_time_cycles = PULSE_TIME_CYCLES_DEFAULT;
+    pulse_power.f = PULSE_POWER_DEFAULT;
+    charge_freq = CHARGE_FREQ_DEFAULT;
     
     while(1) {
         read_line();
@@ -302,7 +320,7 @@ void serial_console() {
             printf("- [fa]st_trigger_configure: delay_cycles=%d, time_cycles=%d\n", pulse_delay_cycles, pulse_time_cycles);
             printf("- [in]ternal_hvp\n");
             printf("- [ex]ternal_hvp\n");
-            printf("- [c]onfigure: pulse_time=%d, pulse_power=%f\n", pulse_time, pulse_power.f);
+            printf("- [c]onfigure: pulse_time=%d, pulse_power=%f, charge_freq=%d\n", pulse_time, pulse_power.f, charge_freq);
             printf("- [t]oggle_gp1\n");
             printf("- [s]tatus\n");
             printf("- [r]eset\n");

--- a/firmware/c/serial.c
+++ b/firmware/c/serial.c
@@ -14,11 +14,11 @@ static char last_command[256];
 #define PULSE_DELAY_CYCLES_DEFAULT 0
 #define PULSE_TIME_CYCLES_DEFAULT 625 // 5us in 8ns cycles
 #define PULSE_TIME_US_DEFAULT 5 // 5us
-#define PULSE_POWER_DEFAULT 0.0122
+#define CHARGE_DUTY_DEFAULT 0.0122
 static uint32_t pulse_time;
 static uint32_t pulse_delay_cycles;
 static uint32_t pulse_time_cycles;
-static union float_union {float f; uint32_t ui32;} pulse_power;
+static union float_union {float f; uint32_t ui32;} charge_duty;
 
 void read_line() {
     memset(serial_buffer, 0, sizeof(serial_buffer));
@@ -230,13 +230,13 @@ bool handle_command(char *command) {
         else
             pulse_time = strtoul(serial_buffer, unused, 10);
 
-        printf(" pulse_power (current: %f, default: %f)?\n> ", pulse_power.f, PULSE_POWER_DEFAULT);
+        printf(" charge_duty (current: %f, default: %f)?\n> ", charge_duty.f, CHARGE_DUTY_DEFAULT);
         read_line();
         printf("\n");
         if (serial_buffer[0] == 0)
             printf("Using default");
         else
-            pulse_power.f = strtof(serial_buffer, unused);
+            charge_duty.f = strtof(serial_buffer, unused);
 
         multicore_fifo_push_blocking(cmd_config_pulse_time);
         multicore_fifo_push_blocking(pulse_time);
@@ -245,14 +245,14 @@ bool handle_command(char *command) {
             printf("Config pulse_time failed.");
         }
 
-        multicore_fifo_push_blocking(cmd_config_pulse_power);
-        multicore_fifo_push_blocking(pulse_power.ui32);
+        multicore_fifo_push_blocking(cmd_config_charge_duty);
+        multicore_fifo_push_blocking(charge_duty.ui32);
         result = multicore_fifo_pop_blocking();
         if(result != return_ok) {
-            printf("Config pulse_power failed.");
+            printf("Config charge_duty failed.");
         }
 
-        printf("pulse_time=%d, pulse_power=%f\n", pulse_time, pulse_power.f);
+        printf("pulse_time=%d, charge_duty=%f\n", pulse_time, charge_duty.f);
 
         return true;
     }
@@ -282,7 +282,7 @@ void serial_console() {
     memset(last_command, 0, sizeof(last_command));
 
     pulse_time = PULSE_TIME_US_DEFAULT;
-    pulse_power.f = PULSE_POWER_DEFAULT;
+    charge_duty.f = CHARGE_DUTY_DEFAULT;
     pulse_delay_cycles = PULSE_DELAY_CYCLES_DEFAULT;
     pulse_time_cycles = PULSE_TIME_CYCLES_DEFAULT;
     
@@ -302,7 +302,7 @@ void serial_console() {
             printf("- [fa]st_trigger_configure: delay_cycles=%d, time_cycles=%d\n", pulse_delay_cycles, pulse_time_cycles);
             printf("- [in]ternal_hvp\n");
             printf("- [ex]ternal_hvp\n");
-            printf("- [c]onfigure: pulse_time=%d, pulse_power=%f\n", pulse_time, pulse_power.f);
+            printf("- [c]onfigure: pulse_time=%d, charge_duty=%f\n", pulse_time, charge_duty.f);
             printf("- [t]oggle_gp1\n");
             printf("- [s]tatus\n");
             printf("- [r]eset\n");

--- a/firmware/c/serial.c
+++ b/firmware/c/serial.c
@@ -153,7 +153,7 @@ bool handle_command(char *command) {
             multicore_fifo_pop_blocking();
             printf("Triggered!\n");
         } else {
-            printf("Setting up fast trigger failed.");
+            printf("Setting up fast trigger failed.\n");
         }
         return true;
     }
@@ -185,14 +185,14 @@ bool handle_command(char *command) {
         multicore_fifo_push_blocking(pulse_delay_cycles);
         uint32_t result = multicore_fifo_pop_blocking();
         if(result != return_ok) {
-            printf("Config pulse_delay_cycles failed.");
+            printf("Config pulse_delay_cycles failed.\n");
         }
 
         multicore_fifo_push_blocking(cmd_config_pulse_time_cycles);
         multicore_fifo_push_blocking(pulse_time_cycles);
         result = multicore_fifo_pop_blocking();
         if(result != return_ok) {
-            printf("Config pulse_time_cycles failed.");
+            printf("Config pulse_time_cycles failed.\n");
         }
 
         printf("pulse_delay_cycles=%d, pulse_time_cycles=%d\n", pulse_delay_cycles, pulse_time_cycles);
@@ -205,7 +205,7 @@ bool handle_command(char *command) {
         if(result == return_ok) {
             printf("Internal HVP mode active!\n");
         } else {
-            printf("Setting up internal HVP mode failed.");
+            printf("Setting up internal HVP mode failed.\n");
         }
         return true;
     }
@@ -215,7 +215,7 @@ bool handle_command(char *command) {
         if(result == return_ok) {
             printf("External HVP mode active!\n");
         } else {
-            printf("Setting up external HVP mode failed.");
+            printf("Setting up external HVP mode failed.\n");
         }
         return true;
     }
@@ -234,7 +234,7 @@ bool handle_command(char *command) {
         read_line();
         printf("\n");
         if (serial_buffer[0] == 0)
-            printf("Using default");
+            printf("Using default\n");
         else
             pulse_power.f = strtof(serial_buffer, unused);
 
@@ -242,14 +242,14 @@ bool handle_command(char *command) {
         multicore_fifo_push_blocking(pulse_time);
         uint32_t result = multicore_fifo_pop_blocking();
         if(result != return_ok) {
-            printf("Config pulse_time failed.");
+            printf("Config pulse_time failed.\n");
         }
 
         multicore_fifo_push_blocking(cmd_config_pulse_power);
         multicore_fifo_push_blocking(pulse_power.ui32);
         result = multicore_fifo_pop_blocking();
         if(result != return_ok) {
-            printf("Config pulse_power failed.");
+            printf("Config pulse_power failed.\n");
         }
 
         printf("pulse_time=%d, pulse_power=%f\n", pulse_time, pulse_power.f);
@@ -262,7 +262,7 @@ bool handle_command(char *command) {
 
         uint32_t result = multicore_fifo_pop_blocking();
         if(result != return_ok) {
-            printf("target_reset failed.");
+            printf("target_reset failed.\n");
         }
 
         return true;

--- a/firmware/c/serial.h
+++ b/firmware/c/serial.h
@@ -11,7 +11,7 @@
 #define cmd_internal_hvp 7
 #define cmd_external_hvp 8
 #define cmd_config_pulse_time 9
-#define cmd_config_pulse_power 10
+#define cmd_config_charge_duty 10
 #define cmd_toggle_gp1 11
 #define cmd_config_pulse_delay_cycles 12
 #define cmd_config_pulse_time_cycles 13

--- a/firmware/c/serial.h
+++ b/firmware/c/serial.h
@@ -15,6 +15,7 @@
 #define cmd_toggle_gp1 11
 #define cmd_config_pulse_delay_cycles 12
 #define cmd_config_pulse_time_cycles 13
+#define cmd_config_charge_freq 14
 
 #define return_ok 0
 #define return_failed 1


### PR DESCRIPTION
This PR combines a few changes I've broken out into independent branches, as those changes conflict.

Items 3 and 4 (and arguably item 2) are (minor) breaking changes about the serial console, should someone have scripted against them (`[c]onfigure`, primarily, now expects a third new line).

1. cleanup whitespace
   - because why not
   - (see 2.)
2. newlines (LF) on logging statements
   - for a cleaner console
   - https://github.com/newaetech/chipshouter-picoemp/compare/main...nmschulte:chipshouter-picoemp:nms/whitespace-log-newlines
3. rename `pulse_power` to `charge_duty`
   - for clarity
   - https://github.com/newaetech/chipshouter-picoemp/compare/main...nmschulte:chipshouter-picoemp:nms/rename-pulse-power
4. adjustable charging frequency (`charge_freq`)
   - for the same reasons adjustable duty cycle is useful
   - https://github.com/newaetech/chipshouter-picoemp/compare/main...nmschulte:chipshouter-picoemp:nms/adjustable-charge-frequency-cmd
5. proper arm button debounce logic
   - because it's annoying (#14, #24, ...)
   - https://github.com/newaetech/chipshouter-picoemp/compare/main...nmschulte:chipshouter-picoemp:nms/arm-button-debounce